### PR TITLE
IE bug fix for deleting link from admin

### DIFF
--- a/assets/ilenframework/core.php
+++ b/assets/ilenframework/core.php
@@ -2798,7 +2798,7 @@ function delete_select2_to_dragdrop_{$value['name']}( id ){
 		}
 	}
  
-	jQuery(select2_search_post_{$value["name"]}_values).val(new_ids);
+	jQuery('.select2_search_post_{$value["name"]}_values').val(new_ids);
 	jQuery('#li_select2_item_'+id).remove();
 }
 


### PR DESCRIPTION
Hi,

I saw that deletion of the articles doesn't work in IE 11
It was a small fix, so I did it myself.
You can approve the pull request or just fix it, as you want

Have a nice day,
Raluca Crisan
